### PR TITLE
Twitterアカウントのリンク切れ対策

### DIFF
--- a/src/lib/components/list/Sponser.svelte
+++ b/src/lib/components/list/Sponser.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
-	import type { IHibiscusCupSponserInfo } from '$lib/types';
+	import type { IHibiscusCupSponserInfo, ITwitchUser } from '$lib/types';
     import { Card, Avatar, Button } from 'flowbite-svelte';
     import TwitchLinkIcon from '$lib/components/link-icon/TwitchLinkIcon.svelte';
     import TwitterLinkIcon from '$lib/components/link-icon/TwitterLinkIcon.svelte';
 
     const profile_image_prefix = 'https://pbs.twimg.com/profile_images/';
 
+    export let twitchUserInfo: ITwitchUser[];
     export let sponsers: IHibiscusCupSponserInfo[];
     let role = sponsers.map((sponser) => sponser.role)[0];
 </script>
@@ -16,7 +17,10 @@
         <span class="text-lg text-gray-500 dark:text-gray-400 mr-3">{role}</span>
         {#each sponsers as sponser}
             <div class="flex flex-col items-center">
-                <Avatar size="lg" src="{profile_image_prefix}{sponser.profile_image}" />
+                <Avatar size="lg" 
+                        src="{twitchUserInfo == null || twitchUserInfo.filter((user) => user.login === sponser.twitch).length === 0 ? 
+                                profile_image_prefix + sponser.profile_image : 
+                                twitchUserInfo.filter((user) => user.login === sponser.twitch)[0].profile_image_url}" />
                 <h5 class="mb-1 text-xl font-medium text-gray-900 dark:text-white">{sponser.name}</h5>
                 <div class="flex mt-4 space-x-3 lg:mt-6">
                     <TwitchLinkIcon name={sponser.twitch} />

--- a/src/lib/components/list/Team.svelte
+++ b/src/lib/components/list/Team.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
-	import type { IHibiscusCupMemberInfo } from '$lib/types';
+	import type { IHibiscusCupMemberInfo, ITwitchUser } from '$lib/types';
     import { Card, Dropdown, DropdownItem, Avatar, Button } from 'flowbite-svelte';
     import TwitchLinkIcon from '$lib/components/link-icon/TwitchLinkIcon.svelte';
     import TwitterLinkIcon from '$lib/components/link-icon/TwitterLinkIcon.svelte';
     
     const profile_image_prefix = 'https://pbs.twimg.com/profile_images/';
 
+    export let twitchUserInfo: ITwitchUser[];
     export let members: IHibiscusCupMemberInfo[];
     let teamCode = members.map((member) => member.team)[0];
 </script>
@@ -15,7 +16,8 @@
         <span class="text-lg text-gray-500 dark:text-gray-400">チーム{teamCode}</span>
         {#each members as member}
             <div class="flex flex-col items-center mx-3">
-                <Avatar size="lg" src="{profile_image_prefix}{member.profile_image}" />
+                <Avatar size="lg" 
+                        src="{twitchUserInfo?.filter((user) => user.login === member.twitch)[0].profile_image_url}" />
                 <h5 class="mb-1 text-xl font-medium text-gray-900 dark:text-white">{member.name}</h5>
                 <div class="flex mt-4 space-x-3 lg:mt-6">
                     <TwitchLinkIcon name={member.twitch} />

--- a/src/routes/sponsers/+page.svelte
+++ b/src/routes/sponsers/+page.svelte
@@ -1,25 +1,43 @@
 <script lang="ts">
 	import { HIBISCUS_CUP_SPONSER } from '$lib/member';
     import Sponser from '$lib/components/list/Sponser.svelte';
+	import type { ITwitchUser, ITwitchUserResponse } from '$lib/types';
+    import axios from 'redaxios';
+	import { onMount } from 'svelte';
     
     const sponsers = HIBISCUS_CUP_SPONSER.filter((sponser) => sponser.role === '主催');
     const plans = HIBISCUS_CUP_SPONSER.filter((sponser) => sponser.role === '企画');
     const managers = HIBISCUS_CUP_SPONSER.filter((sponser) => sponser.role === '運営');
     const designers = HIBISCUS_CUP_SPONSER.filter((sponser) => sponser.role === 'ロゴ');
+
+    let twitchUserInfo: ITwitchUser[];
+    const getTwitchUserInfo = async (): Promise<ITwitchUser[]> => {
+        const memberNames = HIBISCUS_CUP_SPONSER.filter((sponser) => sponser.twitch != '').map((sponser) => sponser.twitch);
+        const response = await axios.post<ITwitchUserResponse>(
+            '/api/twitch/users',
+            { names: memberNames }
+        );
+        const users = response.data.users;
+        return users;
+    }
+
+    onMount( async () => {
+        twitchUserInfo = await getTwitchUserInfo();
+    })
 </script>
 
 <div class="flex justify-center flex-wrap">
-    <Sponser {sponsers} />
+    <Sponser {sponsers} {twitchUserInfo}/>
 </div>
 
 <div class="flex justify-center flex-wrap">
-    <Sponser sponsers={plans} />
+    <Sponser sponsers={plans} {twitchUserInfo}/>
 </div>
 
 <div class="flex justify-center flex-wrap">
-    <Sponser sponsers={managers} />
+    <Sponser sponsers={managers} {twitchUserInfo}/>
 </div>
 
 <div class="flex justify-center flex-wrap">
-    <Sponser sponsers={designers} />
+    <Sponser sponsers={designers} {twitchUserInfo}/>
 </div>

--- a/src/routes/teams/+page.svelte
+++ b/src/routes/teams/+page.svelte
@@ -1,18 +1,37 @@
 <script lang="ts">
 	import Team from "$lib/components/list/Team.svelte";
 	import { HIBISCUS_CUP_MEMBER } from "$lib/member";
+    import type { ITwitchUser, ITwitchUserResponse } from '$lib/types';
+    import axios from 'redaxios';
+	import { onMount } from "svelte";
 
     const teamCodes = new Set(HIBISCUS_CUP_MEMBER.map((member) => member.team));
     const getTeamMembers = (teamCode: string) => {
         const members = HIBISCUS_CUP_MEMBER.filter((member) => member.team === teamCode);
         return members
     }
+
+    let twitchUserInfo: ITwitchUser[];
+    const getTwitchUserInfo = async (): Promise<ITwitchUser[]> => {
+        const memberNames = HIBISCUS_CUP_MEMBER.map((member) => member.twitch);
+        const response = await axios.post<ITwitchUserResponse>(
+            '/api/twitch/users',
+            { names: memberNames }
+        );
+        const users = response.data.users;
+        return users;
+    }
+
+    onMount( async () => {
+        twitchUserInfo = await getTwitchUserInfo();
+    })
 </script>
 
 <div class="grid grid-cols-3 gap-4" >
     {#each teamCodes as teamCode}
         <div class="flex flex-col items-center">
-            <Team members={getTeamMembers(teamCode)} />
+            <Team members={getTeamMembers(teamCode)} 
+                  {twitchUserInfo} />
         </div>
     {/each}
 </div>


### PR DESCRIPTION
Twitchアカウントがある場合はTwitterプロフィールアイコンよりもTwitchプロフィールアイコンを優先して表示する 
Twitchアカウントがない場合は引き続きTwitterアカウントのアイコンが変更されるとリンク切れする